### PR TITLE
Deduplicate river related sources and surface counts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import SourceTooltip from "@/components/SourceTooltip";
 import ReadNowButton from "@/components/ReadNowButton";
 import { CATEGORIES } from "@/lib/tagger";
 import { getRiverData } from "@/lib/services/riverService";
+import type { ClusterArticle } from "@/lib/models/cluster";
 
 // Cache for 5 minutes (300 seconds)
 export const revalidate = 300;
@@ -17,6 +18,89 @@ function hostFrom(url: string) {
   } catch {
     return "";
   }
+}
+
+type ArticleIndexEntry = {
+  key: string;
+  normalizedKey: string;
+  articles: ClusterArticle[];
+};
+
+function normalizeSourceKey(value?: string | null) {
+  return value
+    ? value
+        .trim()
+        .toLowerCase()
+        .replace(/^https?:\/\//, "")
+        .replace(/^www\./, "")
+    : "";
+}
+
+function buildArticleIndex(
+  allArticles?: Record<string, ClusterArticle[]> | null
+): Map<string, ArticleIndexEntry> {
+  const index = new Map<string, ArticleIndexEntry>();
+
+  if (!allArticles) {
+    return index;
+  }
+
+  for (const [key, articles] of Object.entries(allArticles)) {
+    const normalizedKey = normalizeSourceKey(key);
+
+    if (!normalizedKey) {
+      continue;
+    }
+
+    index.set(normalizedKey, {
+      key,
+      normalizedKey,
+      articles,
+    });
+  }
+
+  return index;
+}
+
+function findArticlesForSource(
+  index: Map<string, ArticleIndexEntry>,
+  sourceName: string,
+  url: string
+) {
+  const candidates = [sourceName, hostFrom(url)].filter(Boolean) as string[];
+
+  for (const candidate of candidates) {
+    const normalized = normalizeSourceKey(candidate);
+
+    if (!normalized) {
+      continue;
+    }
+
+    const exact = index.get(normalized);
+
+    if (exact) {
+      return exact.articles;
+    }
+  }
+
+  for (const candidate of candidates) {
+    const normalized = normalizeSourceKey(candidate);
+
+    if (!normalized) {
+      continue;
+    }
+
+    for (const entry of index.values()) {
+      if (
+        entry.normalizedKey.includes(normalized) ||
+        normalized.includes(entry.normalizedKey)
+      ) {
+        return entry.articles;
+      }
+    }
+  }
+
+  return [];
 }
 
 export default async function RiverPage(props: {
@@ -52,12 +136,15 @@ export default async function RiverPage(props: {
         <section>
           {clusters.map((r) => {
             const secondaries = r.subs ?? [];
-            const moreCount = Math.max(0, r.subs_total - secondaries.length);
             const isCluster = r.size > 1;
             const publisher = r.lead_source || hostFrom(r.lead_url);
             const leadClickHref = `/api/click?aid=${r.lead_article_id}&url=${encodeURIComponent(
               r.lead_url,
             )}`;
+            const articleIndex = buildArticleIndex(r.all_articles_by_source);
+            const leadArticles = publisher
+              ? findArticlesForSource(articleIndex, publisher, r.lead_url)
+              : [];
 
             return (
               <article
@@ -75,7 +162,7 @@ export default async function RiverPage(props: {
                       )}
                       <SourceTooltip
                         sourceName={publisher}
-                        articles={r.all_articles_by_source?.[publisher] || []}
+                        articles={leadArticles}
                       >
                         {r.lead_homepage ? (
                           <PublisherLink
@@ -134,20 +221,32 @@ export default async function RiverPage(props: {
                       const href = `/api/click?aid=${s.article_id}&url=${encodeURIComponent(
                         s.url,
                       )}`;
-                      const sourceName = s.source ?? hostFrom(s.url);
+                      const sourceName = s.source || hostFrom(s.url);
+                      const articlesForSource = findArticlesForSource(
+                        articleIndex,
+                        sourceName,
+                        s.url,
+                      );
+                      const articleCount =
+                        s.article_count ??
+                        (articlesForSource.length > 0
+                          ? articlesForSource.length
+                          : 1);
+                      const linkLabel =
+                        articleCount > 1
+                          ? `${sourceName} (${articleCount})`
+                          : sourceName;
                       return (
                         <span key={s.article_id}>
                           <SourceTooltip
                             sourceName={sourceName}
-                            articles={
-                              r.all_articles_by_source?.[sourceName] || []
-                            }
+                            articles={articlesForSource}
                           >
                             <a
                               href={href}
                               className="no-underline hover:underline text-zinc-700 hover:text-zinc-900 transition-colors"
                             >
-                              {sourceName}
+                              {linkLabel}
                             </a>
                           </SourceTooltip>
                           {i < secondaries.length - 1 && (

--- a/lib/models/cluster.ts
+++ b/lib/models/cluster.ts
@@ -7,6 +7,7 @@ export type SubLink = {
   source: string | null
   author: string | null
   published_at: string
+  article_count?: number
 }
 
 export type ClusterArticle = {

--- a/lib/services/__tests__/riverService.test.ts
+++ b/lib/services/__tests__/riverService.test.ts
@@ -1,0 +1,113 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { normalizeRiverClusters } from '../riverService'
+import type { Cluster } from '../../models/cluster'
+
+const baseCluster: Cluster = {
+  cluster_id: 1,
+  lead_article_id: 101,
+  lead_title: 'Lead article',
+  lead_url: 'https://example.com/lead',
+  lead_dek: null,
+  lead_source: 'Example Source',
+  lead_homepage: 'https://example.com',
+  lead_author: 'Lead Author',
+  published_at: '2024-05-01T00:00:00Z',
+  size: 4,
+  score: 10,
+  sources_count: 3,
+  subs: [],
+  subs_total: 0,
+  all_articles_by_source: {},
+  lead_content_status: null,
+  lead_content_word_count: null,
+}
+
+describe('normalizeRiverClusters', () => {
+  it('deduplicates subs by source, keeps newest article, and sets counts', () => {
+    const cluster: Cluster = {
+      ...baseCluster,
+      subs: [
+        {
+          article_id: 201,
+          title: 'Bloomberg story 1',
+          url: 'https://www.bloomberg.com/story-1',
+          source: 'Bloomberg',
+          author: 'Reporter 1',
+          published_at: '2024-05-01T10:00:00Z',
+        },
+        {
+          article_id: 202,
+          title: 'Bloomberg story 2',
+          url: 'https://www.bloomberg.com/story-2',
+          source: 'Bloomberg',
+          author: 'Reporter 2',
+          published_at: '2024-05-01T12:00:00Z',
+        },
+        {
+          article_id: 203,
+          title: 'Reuters story 1',
+          url: 'https://www.reuters.com/story-1',
+          source: null,
+          author: 'Reporter 3',
+          published_at: '2024-05-01T09:00:00Z',
+        },
+        {
+          article_id: 204,
+          title: 'Reuters story 2',
+          url: 'https://www.reuters.com/story-2',
+          source: null,
+          author: 'Reporter 4',
+          published_at: '2024-05-01T11:00:00Z',
+        },
+      ],
+      subs_total: 4,
+      all_articles_by_source: {
+        Bloomberg: [
+          {
+            article_id: 201,
+            title: 'Bloomberg story 1',
+            url: 'https://www.bloomberg.com/story-1',
+            author: 'Reporter 1',
+          },
+          {
+            article_id: 202,
+            title: 'Bloomberg story 2',
+            url: 'https://www.bloomberg.com/story-2',
+            author: 'Reporter 2',
+          },
+        ],
+        Reuters: [
+          {
+            article_id: 203,
+            title: 'Reuters story 1',
+            url: 'https://www.reuters.com/story-1',
+            author: 'Reporter 3',
+          },
+          {
+            article_id: 204,
+            title: 'Reuters story 2',
+            url: 'https://www.reuters.com/story-2',
+            author: 'Reporter 4',
+          },
+        ],
+      },
+    }
+
+    const [normalized] = normalizeRiverClusters([cluster])
+
+    assert.equal(normalized.subs.length, 2)
+    assert.equal(normalized.subs_total, 2)
+
+    const bloomberg = normalized.subs.find((sub) => sub.source === 'Bloomberg')
+    assert.ok(bloomberg)
+    assert.equal(bloomberg!.article_id, 202)
+    assert.equal(bloomberg!.article_count, 2)
+
+    const reuters = normalized.subs.find((sub) => (sub.source ?? '').includes('Reuters'))
+    assert.ok(reuters)
+    assert.equal(reuters!.article_id, 204)
+    assert.equal(reuters!.article_count, 2)
+  })
+})


### PR DESCRIPTION
## Summary
- collapse duplicate secondary sources in the river service while preserving the newest link per outlet and computing article counts
- display per-source article counts on the homepage related-article pills without breaking the existing tooltips, and reuse the aggregated article lookup for the lead source tooltip as well
- add a node:test suite that exercises the normalization logic against duplicate secondary articles

## Testing
- npx tsx --test lib/services/__tests__/riverService.test.ts
- pnpm run build *(fails: next/font cannot download Inclusive Sans from Google Fonts in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e046b079a4833296c2d089f711a2c0