### PR TITLE
Remove unused string similarity dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "react-dom": "19.1.1",
     "rss-parser": "^3.12.0",
     "stopword": "^3.0.1",
-    "string-similarity": "^4.0.4",
     "vaul": "^1.1.2"
   },
   "devDependencies": {
@@ -42,7 +41,6 @@
     "@types/pg": "^8.15.5",
     "@types/react": "19.1.14",
     "@types/react-dom": "19.1.9",
-    "@types/string-similarity": "^4.0.2",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       stopword:
         specifier: ^3.0.1
         version: 3.1.5
-      string-similarity:
-        specifier: ^4.0.4
-        version: 4.0.4
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.1.9(@types/react@19.1.14))(@types/react@19.1.14)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -81,9 +78,6 @@ importers:
       '@types/react-dom':
         specifier: 19.1.9
         version: 19.1.9(@types/react@19.1.14)
-      '@types/string-similarity':
-        specifier: ^4.0.2
-        version: 4.0.2
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
@@ -837,9 +831,6 @@ packages:
   '@types/react@19.1.14':
     resolution: {integrity: sha512-ukd93VGzaNPMAUPy0gRDSC57UuQbnH9Kussp7HBjM06YFi9uZTFhOvMSO2OKqXm1rSgzOE+pVx1k1PYHGwlc8Q==}
 
-  '@types/string-similarity@4.0.2':
-    resolution: {integrity: sha512-LkJQ/jsXtCVMK+sKYAmX/8zEq+/46f1PTQw7YtmQwb74jemS1SlNLmARM2Zml9DgdDTWKAtc5L13WorpHPDjDA==}
-
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
@@ -1423,10 +1414,6 @@ packages:
 
   stopword@3.1.5:
     resolution: {integrity: sha512-OgLYGVFCNa430WOrj9tYZhQge5yg6vd6JsKredveAqEhdLVQkfrpnQIGjx0L9lLqzL4Kq4J8yNTcfQR/MpBwhg==}
-
-  string-similarity@4.0.4:
-    resolution: {integrity: sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -2170,8 +2157,6 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
-  '@types/string-similarity@4.0.2': {}
-
   '@types/tough-cookie@4.0.5': {}
 
   '@types/ws@8.18.1':
@@ -2734,8 +2719,6 @@ snapshots:
   split2@4.2.0: {}
 
   stopword@3.1.5: {}
-
-  string-similarity@4.0.4: {}
 
   styled-jsx@5.1.6(react@19.1.1):
     dependencies:


### PR DESCRIPTION
## Summary
- remove the `string-similarity` runtime dependency and its type package from the project manifest
- clean the pnpm lockfile so that the removed packages are no longer referenced

## Testing
- pnpm install *(fails: registry.npmjs.org/zod returned 403 in this environment)*
- pnpm lint *(fails: `lint` script is not defined in package.json)*
- pnpm run build *(fails: Next.js Turbopack cannot download Inclusive Sans from Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e051f13e50833291d2eea768286cb3