### PR TITLE
Ensure ClimateRiverLogo gradients are uniquely scoped

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,12 +35,24 @@ export default async function RootLayout({
             <div className="flex md:items-center md:justify-between max-md:flex-col gap-2 py-3 sm:py-4">
               {/* Left: brand + navigation */}
               <div className="flex items-baseline-last gap-6">
-                <Link href="/" className="flex items-center gap-2 no-underline">
-                  <ClimateRiverLogo
-                    size="lg"
-                    variant="monochrome"
-                    animated={false}
-                  />
+                <Link
+                  href="/"
+                  className="group flex items-center gap-2 no-underline"
+                >
+                  <span className="relative inline-flex" aria-hidden="true">
+                    <ClimateRiverLogo
+                      size="lg"
+                      variant="monochrome"
+                      animated={false}
+                      className="transition-opacity duration-200 ease-out group-hover:opacity-0 group-focus-visible:opacity-0"
+                    />
+                    <ClimateRiverLogo
+                      size="lg"
+                      variant="colored"
+                      animated={false}
+                      className="absolute inset-0 opacity-0 transition-opacity duration-200 ease-out group-hover:opacity-100 group-focus-visible:opacity-100"
+                    />
+                  </span>
                   <span className="font-semibold text-base sm:text-lg">
                     Climate River
                   </span>

--- a/components/ClimateRiverLogo.tsx
+++ b/components/ClimateRiverLogo.tsx
@@ -2,8 +2,8 @@
 
 import React from 'react'
 
-interface ClimateRiverLogoProps {
-  className?: string
+interface ClimateRiverLogoProps
+  extends React.SVGAttributes<SVGSVGElement> {
   animated?: boolean
   size?: 'sm' | 'md' | 'lg' | 'xl'
   variant?: 'monochrome' | 'colored'
@@ -14,6 +14,7 @@ export default function ClimateRiverLogo({
   animated = false,
   size = 'md',
   variant = 'monochrome',
+  ...svgProps
 }: ClimateRiverLogoProps) {
   const sizeClasses = {
     sm: 'w-4 h-4',
@@ -23,9 +24,12 @@ export default function ClimateRiverLogo({
   }
 
   const colorClass = variant === 'monochrome' ? 'text-black' : 'text-current'
+  const uniqueGradientId = React.useId().replace(/:/g, '')
+  const gradientId = `climate-gradient-${uniqueGradientId}`
 
   return (
     <svg
+      {...svgProps}
       version="1.1"
       id="Layer_1"
       xmlns="http://www.w3.org/2000/svg"
@@ -42,7 +46,7 @@ export default function ClimateRiverLogo({
       {variant === 'colored' && (
         <defs>
           <linearGradient
-            id="climate-gradient"
+            id={gradientId}
             x1="0%"
             y1="0%"
             x2="100%"
@@ -59,7 +63,7 @@ export default function ClimateRiverLogo({
       )}
 
       <path
-        fill={variant === 'colored' ? 'url(#climate-gradient)' : 'currentColor'}
+        fill={variant === 'colored' ? `url(#${gradientId})` : 'currentColor'}
         opacity="1.000000"
         stroke="none"
         className={animated ? 'animate-flow' : ''}


### PR DESCRIPTION
## Summary
- allow ClimateRiverLogo to forward standard SVG attributes for accessibility hooks
- generate unique gradient ids per instance so stacked colored logos do not clash in the DOM

## Testing
- pnpm build *(fails: next/font could not fetch Inclusive Sans from Google Fonts in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e060eb68188332a696d6bace3904a5